### PR TITLE
Increased unit test cov to 98%

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This NApps depends on `kytos/of_core` and OpenFlow 1.3.
 Supported Features
 ==================
 
-The following `OFPAT_EXPERIMENTER` custom action types are supported:
+The following ``OFPAT_EXPERIMENTER`` custom action types are supported:
 
   .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+|Build| |Coverage| |Quality| |Tag| |License|
+
 Overview
 ========
 Implement Noviflow-specific features
@@ -31,3 +33,18 @@ The following `OFPAT_EXPERIMENTER` custom action types are supported:
 
         # Send INT report
         NOVI_ACTION_SEND_REPORT = 15
+
+.. TAGs
+
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/noviflow/badges/build.png?b=master
+  :alt: Build status
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/noviflow/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos-ng/noviflow/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/noviflow/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos-ng/noviflow/?branch=master
+.. |Tag| image:: https://img.shields.io/github/tag/kytos-ng/noviflow.svg
+   :target: https://github.com/kytos-ng/noviflow/tags
+.. |License| image:: https://img.shields.io/github/license/kytos-ng/noviflow.svg
+   :target: https://github.com/kytos-ng/noviflow/blob/master/LICENSE

--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,30 @@ Implement Noviflow-specific features
 
 Requirements
 ============
+
+This NApps depends on `kytos/of_core` and OpenFlow 1.3.
+
+Supported Features
+==================
+
+The following `OFPAT_EXPERIMENTER` custom action types are supported:
+
+  .. code-block:: python
+
+    class NoviActionType(IntEnum):
+        """Noviflow custom actions."""
+
+        # Set BFD
+        NOVI_ACTION_SET_BFD_DATA = 4
+
+        # Push INT
+        NOVI_ACTION_PUSH_INT = 12
+
+        # Modify INT
+        NOVI_ACTION_ADD_INT_METADATA = 13
+
+        # Pop INT
+        NOVI_ACTION_POP_INT = 14
+
+        # Send INT report
+        NOVI_ACTION_SEND_REPORT = 15

--- a/of_core/v0x04/action.py
+++ b/of_core/v0x04/action.py
@@ -25,11 +25,11 @@ class NoviActionSetBfdData(ActionBase):
     @classmethod
     def from_of_action(cls, of_action):
         """Return a high-level NoviActionSetBfdData instance from pyof."""
-        return cls(port_no=of_action.port_no.value,
-                   my_disc=of_action.my_disc.value,
-                   interval=of_action.interval.value,
-                   multiplier=of_action.multiplier.value,
-                   keep_alive_timeout=of_action.keep_alive_timeout.value)
+        return cls(port_no=int(of_action.port_no),
+                   my_disc=int(of_action.my_disc),
+                   interval=int(of_action.interval),
+                   multiplier=int(of_action.multiplier),
+                   keep_alive_timeout=int(of_action.keep_alive_timeout))
 
     def as_of_action(self):
         """Return a pyof NoviActionSetBfdData instance."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -27,7 +27,6 @@ from napps.amlight.noviflow.pyof.v0x04.action import (
 )
 from napps.amlight.noviflow.pyof.v0x04.action import NoviActionType
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
-from pyof.foundation.basic_types import UBInt8, UBInt32
 
 from kytos.lib.helpers import get_controller_mock, get_switch_mock
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 """Test Main methods."""
 from unittest import TestCase
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from napps.amlight.noviflow.of_core.v0x04.action import (
@@ -45,6 +46,13 @@ class TestMain(TestCase):
         self.napp = Main(controller)
         self.napp.register_actions()
         self.mock_switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+
+    def test_execute_register_actions(self) -> None:
+        """Test register_actions is executed."""
+        mock = MagicMock()
+        self.napp.register_actions = mock()
+        self.napp.execute()
+        assert mock.call_count == 1
 
     def test_create_noviactions(self):
         """Test creating NoviAction classes from a Flow04."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -232,11 +232,11 @@ class TestMain(TestCase):
     def test_noviaction_set_bfd_data(self):
         """Test NoviActionSetBfdData experimenter pack and unpack."""
 
-        port_no = UBInt32(2)
-        my_disc = UBInt32(1)
-        interval = UBInt32(5)
-        multiplier = UBInt8(3)
-        keep_alive_timeout = UBInt8(15)
+        port_no = 2
+        my_disc = 1
+        interval = 5
+        multiplier = 3
+        keep_alive_timeout = 15
 
         action = OFNoviActionSetBfdData(
             port_no=port_no,


### PR DESCRIPTION
I've been merging some PRs recently on this repo and I noticed some low hanging fruits to increase test cov, so took the opportunity to do so, added cov for these methods: 

```
- from_of_action
- as_of_action
```

I've also updated the README.md with some basic info, @ajoaoff might update with more details later if needed. 

#### Before

```
============================================================================= 5 passed, 6 warnings in 1.64s ==============================================================================
Name                      Stmts   Miss  Cover
---------------------------------------------
__init__.py                   0      0   100%
main.py                      14      2    86%
of_core/v0x04/action.py      42     10    76%
pyof/v0x04/action.py         64      1    98%
settings.py                   0      0   100%
---------------------------------------------
TOTAL                       120     13    89%
```

#### After

```
============================================================================= 6 passed, 7 warnings in 1.51s ==============================================================================
Name                      Stmts   Miss  Cover
---------------------------------------------
__init__.py                   0      0   100%
main.py                      14      1    93%
of_core/v0x04/action.py      42      0   100%
pyof/v0x04/action.py         64      1    98%
settings.py                   0      0   100%
---------------------------------------------
TOTAL                       120      2    98%
```