### PR TITLE
[Fix] Revert `from_of_action` forced cast

### DIFF
--- a/of_core/v0x04/action.py
+++ b/of_core/v0x04/action.py
@@ -25,11 +25,11 @@ class NoviActionSetBfdData(ActionBase):
     @classmethod
     def from_of_action(cls, of_action):
         """Return a high-level NoviActionSetBfdData instance from pyof."""
-        return cls(port_no=int(of_action.port_no),
-                   my_disc=int(of_action.my_disc),
-                   interval=int(of_action.interval),
-                   multiplier=int(of_action.multiplier),
-                   keep_alive_timeout=int(of_action.keep_alive_timeout))
+        return cls(port_no=of_action.port_no.value,
+                   my_disc=of_action.my_disc.value,
+                   interval=of_action.interval.value,
+                   multiplier=of_action.multiplier.value,
+                   keep_alive_timeout=of_action.keep_alive_timeout.value)
 
     def as_of_action(self):
         """Return a pyof NoviActionSetBfdData instance."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,6 @@
 """Test Main methods."""
 from unittest import TestCase
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from napps.amlight.noviflow.of_core.v0x04.action import (
     NoviActionAddIntMetadata,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -27,6 +27,7 @@ from napps.amlight.noviflow.pyof.v0x04.action import (
 )
 from napps.amlight.noviflow.pyof.v0x04.action import NoviActionType
 from napps.kytos.of_core.v0x04.flow import Flow as Flow04
+from pyof.foundation.basic_types import UBInt8, UBInt32
 
 from kytos.lib.helpers import get_controller_mock, get_switch_mock
 
@@ -292,4 +293,3 @@ class TestMain(TestCase):
         assert as_of_action.interval == interval
         assert as_of_action.multiplier == multiplier
         assert as_of_action.keep_alive_timeout == keep_alive_timeout
-

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -231,11 +231,11 @@ class TestMain(TestCase):
     def test_noviaction_set_bfd_data(self):
         """Test NoviActionSetBfdData experimenter pack and unpack."""
 
-        port_no = 2
-        my_disc = 1
-        interval = 5
-        multiplier = 3
-        keep_alive_timeout = 15
+        port_no = UBInt32(2)
+        my_disc = UBInt32(1)
+        interval = UBInt32(5)
+        multiplier = UBInt8(3)
+        keep_alive_timeout = UBInt8(15)
 
         action = OFNoviActionSetBfdData(
             port_no=port_no,


### PR DESCRIPTION
This reverts a change on `from_of_action` that was introduced on PR #8. [Antonio has clarified on this comment](https://github.com/kytos-ng/noviflow/pull/8#discussion_r773354915) that the instance argument passed to `from_of_action` is indeed expected to have `UBInt` values, although currently this classmethod isn't being used, but it'll be consistent if required later on. 