### PR TITLE
Update requirements to make it compatible with py39

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,7 +32,7 @@ click==8.0.3
     #   pip-tools
 coverage==6.2
     # via kytos-noviflow
-dataclasses==0.8
+dataclasses==0.8; python_version < "3.7"
     # via black
 decorator==4.4.2
     # via


### PR DESCRIPTION
This is a complement to PR #13 

### Description of the change

- Adding a conditional to `requirements/dev.txt` to avoid trying to install dataclasses in recent python versions (PEP 557)

### Change log

N/A