### PR TITLE
[Fix] Action object has no attribute 'as_dict'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Removed
 
 Fixed
 =====
+- Fixed Action object has no attribute 'as_dict'
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -9,10 +9,20 @@ from napps.amlight.noviflow.of_core.v0x04.action import (
     NoviActionPushInt,
     NoviActionSendReport,
     NoviActionSetBfdData,
+)
+from napps.amlight.noviflow.pyof.v0x04.action import (
     NoviActionAddIntMetadata as OFNoviActionAddIntMetadata,
+)
+from napps.amlight.noviflow.pyof.v0x04.action import (
     NoviActionPopInt as OFNoviActionPopInt,
+)
+from napps.amlight.noviflow.pyof.v0x04.action import (
     NoviActionPushInt as OFNoviActionPushInt,
+)
+from napps.amlight.noviflow.pyof.v0x04.action import (
     NoviActionSendReport as OFNoviActionSendReport,
+)
+from napps.amlight.noviflow.pyof.v0x04.action import (
     NoviActionSetBfdData as OFNoviActionSetBfdData,
 )
 from napps.kytos.of_core.v0x04.flow import Action
@@ -34,7 +44,7 @@ class Main(KytosNApp):
 
         So, if you have any setup routine, insert it here.
         """
-        self.NOVIFLOW_ACTIONS = {
+        self.noviflow_actions = {
             "set_bfd": NoviActionSetBfdData,
             "push_int": NoviActionPushInt,
             "add_int_metadata": NoviActionAddIntMetadata,
@@ -66,5 +76,5 @@ class Main(KytosNApp):
 
     def register_actions(self):
         """Add new actions to kytos/of_core."""
-        for name, action in self.NOVIFLOW_ACTIONS.items():
+        for name, action in self.noviflow_actions.items():
             Action.add_action_class(name, action)

--- a/main.py
+++ b/main.py
@@ -9,18 +9,15 @@ from napps.amlight.noviflow.of_core.v0x04.action import (
     NoviActionPushInt,
     NoviActionSendReport,
     NoviActionSetBfdData,
+    NoviActionAddIntMetadata as OFNoviActionAddIntMetadata,
+    NoviActionPopInt as OFNoviActionPopInt,
+    NoviActionPushInt as OFNoviActionPushInt,
+    NoviActionSendReport as OFNoviActionSendReport,
+    NoviActionSetBfdData as OFNoviActionSetBfdData,
 )
 from napps.kytos.of_core.v0x04.flow import Action
 
 from kytos.core import KytosNApp
-
-NOVIFLOW_ACTIONS = {
-    "set_bfd": NoviActionSetBfdData,
-    "push_int": NoviActionPushInt,
-    "add_int_metadata": NoviActionAddIntMetadata,
-    "pop_int": NoviActionPopInt,
-    "send_report": NoviActionSendReport,
-}
 
 
 class Main(KytosNApp):
@@ -37,7 +34,18 @@ class Main(KytosNApp):
 
         So, if you have any setup routine, insert it here.
         """
-        pass
+        self.NOVIFLOW_ACTIONS = {
+            "set_bfd": NoviActionSetBfdData,
+            "push_int": NoviActionPushInt,
+            "add_int_metadata": NoviActionAddIntMetadata,
+            "pop_int": NoviActionPopInt,
+            "send_report": NoviActionSendReport,
+            OFNoviActionSetBfdData: NoviActionSetBfdData,
+            OFNoviActionPushInt: NoviActionPushInt,
+            OFNoviActionAddIntMetadata: NoviActionAddIntMetadata,
+            OFNoviActionPopInt: NoviActionPopInt,
+            OFNoviActionSendReport: NoviActionSendReport,
+        }
 
     def execute(self):
         """Run after the setup method execution.
@@ -56,8 +64,7 @@ class Main(KytosNApp):
         """
         pass
 
-    @staticmethod
-    def register_actions():
+    def register_actions(self):
         """Add new actions to kytos/of_core."""
-        for name, action in NOVIFLOW_ACTIONS.items():
+        for name, action in self.NOVIFLOW_ACTIONS.items():
             Action.add_action_class(name, action)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -292,3 +292,19 @@ class TestMain(TestCase):
         assert as_of_action.interval == interval
         assert as_of_action.multiplier == multiplier
         assert as_of_action.keep_alive_timeout == keep_alive_timeout
+
+    def test_noviflow_actions_dict(self) -> None:
+        """Test NOVIFLOW_ACTIONS dict."""
+        expected_keys = [
+            "set_bfd",
+            "push_int",
+            "add_int_metadata",
+            "pop_int",
+            "send_report",
+            NoviActionSetBfdData,
+            NoviActionPushInt,
+            NoviActionAddIntMetadata,
+            NoviActionPopInt,
+            NoviActionSendReport,
+        ]
+        assert expected_keys == list(self.napp.NOVIFLOW_ACTIONS.keys())

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -301,10 +301,10 @@ class TestMain(TestCase):
             "add_int_metadata",
             "pop_int",
             "send_report",
-            NoviActionSetBfdData,
-            NoviActionPushInt,
-            NoviActionAddIntMetadata,
-            NoviActionPopInt,
-            NoviActionSendReport,
+            OFNoviActionSetBfdData,
+            OFNoviActionPushInt,
+            OFNoviActionAddIntMetadata,
+            OFNoviActionPopInt,
+            OFNoviActionSendReport,
         ]
-        assert expected_keys == list(self.napp.NOVIFLOW_ACTIONS.keys())
+        assert expected_keys == list(self.napp.noviflow_actions.keys())


### PR DESCRIPTION
Fixes #18 

- Fixed Action object has no attribute 'as_dict'

Thanks @italovalcy. Italo, let me know if you could try this branch out on the original scenario