### PR TITLE
[release] Bumped 2022.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,25 +5,13 @@ All notable changes to the noviflow NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
-Added
-=====
 
-Changed
-=======
-
-Deprecated
-==========
-
-Removed
-=======
+[2022.3.0] - 2022-12-15
 
 Fixed
 =====
 - Fixed Action object has no attribute 'as_dict'
 - Hooked ``ActionExperimenter`` subclasses to be deserialized on of_core
-
-Security
-========
 
 [2022.1.0] - 2022-02-08
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "noviflow",
   "description": "Implement Noviflow-specific features",
-  "version": "2022.1.0",
+  "version": "2022.3.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
Closes N/A

### Summary

- Bumped 2022.3.0

I'm bumping the version of NApps that can already be bumped, when the time comes, it's just a matter of merging and creating the GitHub release with its `git` tag. 