### PR TITLE
Bumped version 2022.3.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if "bdist_wheel" in sys.argv:
 BASE_ENV = Path(os.environ.get("VIRTUAL_ENV", "/"))
 
 NAPP_NAME = "noviflow"
-NAPP_VERSION = "2022.1.0"
+NAPP_VERSION = "2022.3.0"
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / "var" / "lib" / "kytos"


### PR DESCRIPTION
This PR is complementary to PR #23, and it bumps the version of the Napp in `setup.py`.