### PR TITLE
release: bumped 2024.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the noviflow NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.0] - 2024-07-23
+***********************
+
+Changed
+=======
+- Updated python environment installation from 3.9 to 3.11
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "noviflow",
   "description": "Implement Noviflow-specific features",
-  "version": "2022.3.0",
+  "version": "2024.1.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION
### Summary

release: bumped 2024.1.0

### Local Tests

N/A

### End-to-End Tests

e2e nightly tests are passing. N/A for this PR.
