### PR TITLE
release: bumped 2023.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the noviflow NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.0] - 2024-10-03
+***********************
+
+No major changes since the last release.
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "noviflow",
   "description": "Implement Noviflow-specific features",
-  "version": "2022.3.0",
+  "version": "2023.2.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "MIT",
   "tags": [],


### PR DESCRIPTION

### Summary

See updated changelog file 

### Local Tests

Not needed

### End-to-End Tests

Not needed
